### PR TITLE
Pkg 4341 mlflow 2.12.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
   - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
   - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/0b02e59
+  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/954a69d

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
   - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
   - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/0b02e59
-  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/d841f38
+  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/cba941b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
-  - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
-  - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/0b02e59
-  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/cba941b

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
   - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
   - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/0b02e59
-  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/954a69d
+  - https://staging.continuum.io/prefect/fs/docker-py-feedstock/pr3/d841f38

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
   - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
-  - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/a49682e
+  - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/0b02e59

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/graphql-relay-feedstock/pr2/a8991c5
+  - https://staging.continuum.io/prefect/fs/graphene-feedstock/pr2/6bf628a
+  - https://staging.continuum.io/prefect/fs/gunicorn-feedstock/pr1/a49682e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,14 +116,9 @@ test:
 {% endif %}
   commands:
     - mlflow --help
-    # docker-py 4.4.1 causes pip check to fail because it expects a precise
-    # version of pywin32 (see below). We cannot currently ignore that single
-    # pip check failure so we have to ignore all of them for now. But the pin
-    # below does allow us to confirm for older versions of Python at least.
     - pip check
   requires:
     - pip
-    - pywin32 227  # [win and py<=38]
 
 about:
   home: https://mlflow.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "2.12.1" %}
+{% set version = "2.12.2" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -23,7 +23,7 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: d270f6503c8e0087c6f31cbe6fef2766d89fff71ff1ff03b1c5858554e279c62
+  sha256: d712f1af9d44f1eb9e1baee8ca64f7311e185b7572fc3c1e0a83a4c8ceff6aad
 
 build:
   number: 0
@@ -59,7 +59,7 @@ requirements:
     - gitpython >=3.1.9,<4
     - importlib-metadata <8,>=3.7.0,!=4.7.0
     - packaging <25
-    - protobuf >=3.12.0,<6
+    - protobuf >=3.12.0,<5
     - pytz <2025
     - pyyaml >=5.1,<7
     - requests >=2.17.3,<3
@@ -71,7 +71,7 @@ requirements:
     - alembic <2,!=1.10.0
     - docker-py >=4.0.0,<8
     - graphene <4
-    - gunicorn <22  # [not win]
+    - gunicorn <23  # [not win]
     - markdown >=3.3,<4
     - matplotlib-base <4
     - numpy <2
@@ -89,7 +89,6 @@ requirements:
     - fastai >=2.4.1
     - spacy >=3.3.0
     - tensorflow >=2.10.0 # [not (osx and arm64)]
-    - tensorflow-macos >=2.10.0 # [osx and arm64]
     - pytorch >=1.11.0
     - torchvision >=0.12.0
     - lightning>=1.8.1
@@ -98,6 +97,22 @@ requirements:
     - holidays !=0.25
     - shap >=0.42.1
     - openai <1.0
+    - azureml-core >=1.2.0
+    - mlserver >=1.2.0, !=1.3.1, <1.4.0
+    - mlserver-mlflow >=1.2.0,!=1.3.1,<1.4.0
+    # mlflow-gateway, mlflow-skinny-gateway, genai
+    - pydantic >=1.0,<3
+    - fastapi <1
+    - uvicorn-standard <1
+    - watchfiles <1
+    - aiohttp <4
+    - boto3 >=1.28.56,<2
+    - tiktoken <1
+    - slowapi >=0.1.9,<1
+    # databricks
+    - azure-storage-file-datalake >12
+    - google-cloud-storage >=1.30.0
+    - boto3 >1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mlflow" %}
-{% set version = "2.9.2" %}
-{% set sha256 = "25f2ad3d0b0e78bd32296058fb4c315dff4379515cd669ac6137f39507b9dfe9" %}
+{% set version = "2.12.1" %}
+{% set sha256 = "aa92aebb2379a9c5484cbe901cdf779d5408ac96a641e4b1f8a2d1ff974db7c9" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ requirements:
     - mxnet !=1.8.0
     - fastai >=2.4.1
     - spacy >=3.3.0
-    - tensorflow >=2.10.0 # [not (osx and arm64)]
+    - tensorflow >=2.10.0
     - pytorch >=1.11.0
     - torchvision >=0.12.0
     - lightning>=1.8.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ package:
   version: {{ version }}
 
 source:
+  # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
   sha256: d270f6503c8e0087c6f31cbe6fef2766d89fff71ff1ff03b1c5858554e279c62
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: d712f1af9d44f1eb9e1baee8ca64f7311e185b7572fc3c1e0a83a4c8ceff6aad
+  sha256: bdec209c55cd33fbe79deb32d6cb9966d50a4674aac00b706e2658ac81ee58bc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,50 +45,51 @@ requirements:
     - wheel
   run:
     - python
-    - click >=7.0,<9.0
-    - cloudpickle <4.0
-    - databricks-cli >=0.8.7,<1
-    - entrypoints <1.0
-    - gitpython >=2.1.0,<4.0
-    - pyyaml >=5.1,<7.0
-    - protobuf >=3.12.0,<5.0
-    - pytz <2024
-    - requests >=2.17.3,<3.0
-    - packaging <24
+    - click >=7.0,<9
+    - cloudpickle <4
+    - entrypoints <1
+    - gitpython >=3.1.9,<4
     - importlib-metadata <8,>=3.7.0,!=4.7.0
-    - sqlparse >=0.4.0,<1.0
+    - packaging <25
+    - protobuf >=3.12.0,<6
+    - pytz <2025
+    - pyyaml >=5.1,<7
+    - requests >=2.17.3,<3
+    - sqlparse >=0.4.0,<1
 {% if mlflow_variant != "skinny" %}
-    - alembic <2,!=1.10.0
-    - docker-py >=4.0.0,<7.0
-    - flask <4.0
-    - numpy <2.0
-    - scipy <2.0
-    - pandas <3.0
-    - querystring_parser <2.0
-    - sqlalchemy >=1.4.0,<3
-    - gunicorn <22  # [not win]
-    - waitress <3  # [win]
-    - scikit-learn <2.0
-    - pyarrow <15,>=4.0.0
-    - markdown >=3.3,<4.0
+    - flask <4
     - jinja2 <4,>=2.11  # [not win]
     - jinja2 <4,>=3.0  # [win]
-    - matplotlib-base <4.0
-    # - prometheus_flask_exporter <1
+    - alembic <2,!=1.10.0
+    - docker-py >=4.0.0,<8
+    - graphene <4
+    - gunicorn <22  # [not win]
+    - markdown >=3.3,<4
+    - matplotlib-base <4
+    - numpy <2
+    - pandas <3
+    - pyarrow <16,>=4.0.0
+    - querystring_parser <2
+    - scikit-learn <2
+    - scipy <2
+    - sqlalchemy >=1.4.0,<3
+    - waitress <4  # [win]
 {% endif %}
   run_constrained:
     - mlflow{{ mlflow_other }} <0a0
     - mxnet !=1.8.0
     - fastai >=2.4.1
     - spacy >=3.3.0
-    - tensorflow >=2.8.0
+    - tensorflow >=2.10.0 # [not (osx and arm64)]
+    - tensorflow-macos >=2.10.0 # [osx and arm64]
     - pytorch >=1.11.0
     - torchvision >=0.12.0
     - lightning>=1.8.1
     - xgboost >=0.82
     - onnx >=1.11.0
+    - holidays !=0.25
     - shap >=0.42.1
-    - openai<1.0
+    - openai <1.0
 
 test:
   imports:
@@ -112,7 +113,7 @@ test:
     # version of pywin32 (see below). We cannot currently ignore that single
     # pip check failure so we have to ignore all of them for now. But the pin
     # below does allow us to confirm for older versions of Python at least.
-    - pip check  # [not win]
+    - pip check
   requires:
     - pip
     - pywin32 227  # [win and py<=38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "mlflow" %}
 {% set version = "2.12.1" %}
-{% set sha256 = "aa92aebb2379a9c5484cbe901cdf779d5408ac96a641e4b1f8a2d1ff974db7c9" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -22,8 +21,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
+  sha256: d270f6503c8e0087c6f31cbe6fef2766d89fff71ff1ff03b1c5858554e279c62
 
 build:
   number: 0
@@ -34,8 +33,16 @@ build:
 {% if mlflow_variant == "skinny" %}
     export MLFLOW_SKINNY=1  # [not win]
     set MLFLOW_SKINNY=1  # [win]
+    cp {{ SRC_DIR}}/pyproject.toml orig_pyproject.toml  # [not win]
+    copy {{ SRC_DIR}}/pyproject.toml orig_pyproject.toml  # [win]
+    cp {{ SRC_DIR}}/pyproject.skinny.toml pyproject.toml  # [not win]
+    copy {{ SRC_DIR}}/pyproject.skinny.toml pyproject.toml  # [win]
 {% endif %}
     {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+{% if mlflow_variant == "skinny" %}
+    cp orig_pyproject.toml pyproject.toml  # [not win]
+    copy orig_pyproject.toml pyproject.toml  # [win]
+{% endif %}
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ build:
 {% if mlflow_variant == "skinny" %}
     export MLFLOW_SKINNY=1  # [not win]
     set MLFLOW_SKINNY=1  # [win]
-    cp {{ SRC_DIR}}/pyproject.toml orig_pyproject.toml  # [not win]
-    copy {{ SRC_DIR}}/pyproject.toml orig_pyproject.toml  # [win]
-    cp {{ SRC_DIR}}/pyproject.skinny.toml pyproject.toml  # [not win]
-    copy {{ SRC_DIR}}/pyproject.skinny.toml pyproject.toml  # [win]
+    cp {{ SRC_DIR }}/pyproject.toml orig_pyproject.toml  # [not win]
+    copy {{ SRC_DIR }}\pyproject.toml orig_pyproject.toml  # [win]
+    cp {{ SRC_DIR }}/pyproject.skinny.toml pyproject.toml  # [not win]
+    copy {{ SRC_DIR }}\pyproject.skinny.toml pyproject.toml  # [win]
 {% endif %}
     {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 {% if mlflow_variant == "skinny" %}


### PR DESCRIPTION
mlflow 2.12.2

**Destination channel:** defaults

### Links

- [PKG-4341](https://anaconda.atlassian.net/browse/PKG-4341) 
- [Upstream repository](https://github.com/mlflow/mlflow/tree/v2.12.1)
- [Upstream changelog/diff](https://github.com/mlflow/mlflow/blob/v2.12.1/CHANGELOG.md)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/graphql-relay-feedstock/pull/2 > https://github.com/AnacondaRecipes/graphene-feedstock/pull/2 > https://github.com/AnacondaRecipes/mlflow-feedstock/pull/6
  - https://github.com/AnacondaRecipes/gunicorn-feedstock/pull/1

### Explanation of changes:

- Updated to latest

[PKG-4341]: https://anaconda.atlassian.net/browse/PKG-4341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ