### PR TITLE
mlflow 2.18.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 mlflow_variant:
- - default
- - skinny
+  - default
+  - skinny

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ requirements:
     - waitress <4  # [win]
 {% endif %}
   run_constrained:
-    - {{ mlflow_other }} <0a0
+    - mlflow{{ mlflow_other }} <0a0
     # extras
     - google-cloud-storage >=1.30.0
     - azureml-core >=1.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "2.17.2" %}
+{% set version = "2.18.0" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -23,13 +23,11 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: 84c6cad59877f1de177175ef619c0e0d6fe3e617b060cc75fbd2696b9e50e380
+  sha256: 910ad1e2fce93b412063637d465e9291c99678a3bbccbf2b4f7736887321f44b
 
 build:
   number: 0
-  entry_points:
-    - mlflow=mlflow.cli:cli
-  skip: true  # [py<38 or s390x]
+  skip: true  # [py<39 or s390x]
   script: |
 {% if mlflow_variant == "skinny" %}
     export MLFLOW_SKINNY=1  # [not win]
@@ -44,6 +42,8 @@ build:
     cp orig_pyproject.toml pyproject.toml  # [not win]
     copy orig_pyproject.toml pyproject.toml  # [win]
 {% endif %}
+  entry_points:
+    - mlflow=mlflow.cli:cli
 
 requirements:
   host:
@@ -80,7 +80,7 @@ requirements:
     - matplotlib-base <4
     - numpy <3
     - pandas <3
-    - pyarrow <18,>=4.0.0
+    - pyarrow <19,>=4.0.0
     - scikit-learn <2
     - scipy <2
     - sqlalchemy >=1.4.0,<3
@@ -88,10 +88,12 @@ requirements:
 {% endif %}
   run_constrained:
     - mlflow{{ mlflow_other }} <0a0
+    # extras
     - google-cloud-storage >=1.30.0
     - azureml-core >=1.2.0
-    - mlserver >=1.2.0, !=1.3.1, <1.4.0
-    - mlserver-mlflow >=1.2.0,!=1.3.1,<1.4.0
+    # mlserver
+    - mlserver >=1.2.0, !=1.3.1
+    - mlserver-mlflow >=1.2.0,!=1.3.1
     # mlflow-gateway, mlflow-skinny-gateway, genai
     - pydantic >=1.0,<3
     - fastapi <1
@@ -105,6 +107,8 @@ requirements:
     - azure-storage-file-datalake >12
     - google-cloud-storage >=1.30.0
     - boto3 >1
+    # langchain
+    - langchain >=0.1.0,<=0.3.7
 
 test:
   imports:
@@ -125,20 +129,28 @@ test:
 {% endif %}
   source_files:
     - tests/artifacts
+  requires:
+    - pip
+    - pytest
+    - pillow
+    - numpy
   commands:
     - mlflow --help
+    - mlflow --version
     - pip check
     # these tests come from the conda-forge recipe
 {% if mlflow_variant != "skinny" %}
     - mlflow recipes --help
     # This should not be packaged
-    - test ! -f $SP_DIR/pylint_plugins  # [unix]
+    - test ! -f $SP_DIR/pylint_plugins           # [unix]
+    - echo "Checking 'mlflow' exists..."         # [unix]
     - pip list | grep "mlflow \+${PKG_VERSION}"  # [unix]
     # smoke tests
     # skip test_log_artifact_windows_path_with_hostname (run only for win)
     # because needs a data file
     - pytest -vv tests/artifacts -k "not test_log_artifact_windows_path_with_hostname"
 {% else %}
+    - echo "Checking 'mlflow-skinny' exists..."         # [unix]
     - pip list | grep "mlflow-skinny \+${PKG_VERSION}"  # [unix]
     # smoke tests
     # skip test_load_image because numpy is not included in the skinny variant
@@ -148,11 +160,6 @@ test:
 {% endif %}
     # test from .github/workflows/test-package-build.yml#L97
     - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
-  requires:
-    - pip
-    - pytest
-    - pillow
-    - numpy
 
 about:
   home: https://mlflow.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@
 
 {% if mlflow_variant == "skinny" %}
 {% set mlflow_suffix = "-skinny" %}
-{% set mlflow_other = "mlflow" %}
+{% set mlflow_other = "" %}
 {% else %}
 {% set mlflow_suffix = "" %}
-{% set mlflow_other = "mlflow-skinny" %}
+{% set mlflow_other = "-skinny" %}
 {% endif %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "2.16.2" %}
+{% set version = "2.17.2" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -23,7 +23,7 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: d101bf639b7671408d67d357f4af207e8655a41d50ca3befa951026d49751e39
+  sha256: 84c6cad59877f1de177175ef619c0e0d6fe3e617b060cc75fbd2696b9e50e380
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@
 
 {% if mlflow_variant == "skinny" %}
 {% set mlflow_suffix = "-skinny" %}
-{% set mlflow_other = "" %}
+{% set mlflow_other = "mlflow" %}
 {% else %}
 {% set mlflow_suffix = "" %}
-{% set mlflow_other = "-skinny" %}
+{% set mlflow_other = "mlflow-skinny" %}
 {% endif %}
 
 package:
@@ -37,7 +37,7 @@ build:
     cp {{ SRC_DIR }}/pyproject.skinny.toml pyproject.toml  # [not win]
     copy {{ SRC_DIR }}\pyproject.skinny.toml pyproject.toml  # [win]
 {% endif %}
-    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 {% if mlflow_variant == "skinny" %}
     cp orig_pyproject.toml pyproject.toml  # [not win]
     copy orig_pyproject.toml pyproject.toml  # [win]
@@ -87,7 +87,7 @@ requirements:
     - waitress <4  # [win]
 {% endif %}
   run_constrained:
-    - mlflow{{ mlflow_other }} <0a0
+    - {{ mlflow_other }} <0a0
     # extras
     - google-cloud-storage >=1.30.0
     - azureml-core >=1.2.0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6051](https://anaconda.atlassian.net/browse/PKG-6051) 
- [Upstream repository](https://github.com/mlflow/mlflow/tree/v2.18.0)
- Requirements:
  - https://github.com/mlflow/mlflow/blob/v2.18.0/pyproject.skinny.toml
  - https://github.com/mlflow/mlflow/blob/v2.18.0/requirements/skinny-requirements.txt
  - https://github.com/mlflow/mlflow/blob/v2.18.0/pyproject.toml 
  - https://github.com/mlflow/mlflow/blob/v2.18.0/requirements/core-requirements.txt

### Explanation of changes:
- Fix indentation in cbc.yaml
- Skip py<39
- Update runtime and `run_constrained` pinnings. 
- Add `langchain >=0.1.0,<=0.3.7` to `run_constrained`
- Add `mlflow --version` command to tests

### Notes:

- There was a conda-build bug in v24.11.0/24.11.1 https://github.com/conda/conda-build/issues/5416, that blocked our CI on `win-64` but it was fixed, and there is no need to rewrite as a multi-output recipe https://github.com/AnacondaRecipes/mlflow-feedstock/pull/9

[PKG-6051]: https://anaconda.atlassian.net/browse/PKG-6051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ