### PR TITLE
mlflow 2.18.0: make a multi-output recipe

### DIFF
--- a/recipe/README_SKINNY.rst
+++ b/recipe/README_SKINNY.rst
@@ -1,0 +1,15 @@
+=======================================================================
+MLflow Skinny: A Lightweight Machine Learning Lifecycle Platform Client
+=======================================================================
+
+MLflow Skinny is a lightweight MLflow package without SQL storage, server, UI, or data science dependencies.
+MLflow Skinny supports:
+
+* Tracking operations (logging / loading / searching params, metrics, tags + logging / loading artifacts)
+* Model registration, search, artifact loading, and transitions
+* Execution of GitHub projects within notebook & against a remote target.
+
+Additional dependencies can be installed to leverage the full feature set of MLflow. For example:
+
+* To use the `mlflow.sklearn` component of MLflow Models, install `scikit-learn`, `numpy`, and `pandas`.
+* To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.

--- a/recipe/build-mlflow.bat
+++ b/recipe/build-mlflow.bat
@@ -1,0 +1,38 @@
+@echo on
+
+if not exist pyproject-full.toml (
+    copy pyproject.toml pyproject.full.toml
+)
+
+if [%PKG_NAME%] == [mlflow-skinny] (
+  set MLFLOW_SKINNY=1
+  # https://github.com/mlflow/mlflow/pull/4134
+  copy %RECIPE_DIR%/README_SKINNY.rst %SRC_DIR%
+  copy pyproject.skinny.toml pyproject.toml
+) else (
+  copy pyproject.full.toml pyproject.toml
+)
+
+if [%PKG_NAME%] == [mlflow-ui] (
+  pushd mlflow\server\js
+
+  @rem The lockfile is not installable in an immutable fashion on Windows
+  set YARN_ENABLE_IMMUTABLE_INSTALLS=false
+  cmd /c yarn install
+  if %ERRORLEVEL% neq 0 exit 1
+  cmd /c yarn build
+  if %ERRORLEVEL% neq 0 exit 1
+
+  popd
+)
+
+%PREFIX%/python.exe -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+if %ERRORLEVEL% neq 0 exit 1
+
+xcopy /i /s /y mlflow\server\js\build %SP_DIR%\mlflow\server\js\build
+
+if [%PKG_NAME%] NEQ [mlflow-ui-dbg] (
+  rmdir /s /q %SP_DIR%\mlflow\server\js\node_modules
+  bash -c 'rm -f ${SP_DIR//\\\\//}/mlflow/server/js/build/static/css/*.css.map'
+  bash -c 'rm -f ${SP_DIR//\\\\//}/mlflow/server/js/build/static/js/*.js.map'
+)

--- a/recipe/build-mlflow.sh
+++ b/recipe/build-mlflow.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ ! -f pyproject.full.toml ]; then
+  cp pyproject.toml pyproject.full.toml
+fi
+
+if [[ "${PKG_NAME}" == "mlflow-skinny" ]]; then
+  export MLFLOW_SKINNY=1
+  # https://github.com/mlflow/mlflow/pull/4134
+  cp ${RECIPE_DIR}/README_SKINNY.rst ${SRC_DIR}
+  cp pyproject.skinny.toml pyproject.toml
+else
+  cp pyproject.full.toml pyproject.toml
+fi
+
+if [[ "${PKG_NAME}" == "mlflow-ui" ]]; then
+  pushd mlflow/server/js
+  yarn install
+  yarn build
+  popd
+fi
+
+$PREFIX/bin/python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+if [[ "$PKG_NAME" != "mlflow-ui-dbg" ]]; then
+  rm -rf $SP_DIR/mlflow/server/js/node_modules
+  rm -f $SP_DIR/mlflow/server/js/build/static/css/*.css.map
+  rm -f $SP_DIR/mlflow/server/js/build/static/js/*.js.map
+fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-mlflow_variant:
-  - default
-  - skinny

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 mlflow_variant:
- - default
- - skinny
+  - default
+  - skinny

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,14 +37,14 @@ outputs:
         - wheel
       run:
         - python
-        - cachetools<6,>=5.0.0
+        - cachetools <6,>=5.0.0
         - click >=7.0,<9
         - cloudpickle <4
         - databricks-sdk <1,>=0.20.0
         - gitpython >=3.1.9,<4
         - importlib-metadata <9,>=3.7.0,!=4.7.0
-        - opentelemetry-api<3,>=1.9.0
-        - opentelemetry-sdk<3,>=1.9.0
+        - opentelemetry-api <3,>=1.9.0
+        - opentelemetry-sdk <3,>=1.9.0
         - packaging <25
         - protobuf >=3.12.0,<6
         # required on imports for win

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "2.17.2" %}
+{% set version = "2.18.0" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -23,13 +23,11 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: 84c6cad59877f1de177175ef619c0e0d6fe3e617b060cc75fbd2696b9e50e380
+  sha256: 910ad1e2fce93b412063637d465e9291c99678a3bbccbf2b4f7736887321f44b
 
 build:
   number: 0
-  entry_points:
-    - mlflow=mlflow.cli:cli
-  skip: true  # [py<38 or s390x]
+  skip: true  # [py<39 or s390x]
   script: |
 {% if mlflow_variant == "skinny" %}
     export MLFLOW_SKINNY=1  # [not win]
@@ -44,6 +42,8 @@ build:
     cp orig_pyproject.toml pyproject.toml  # [not win]
     copy orig_pyproject.toml pyproject.toml  # [win]
 {% endif %}
+  entry_points:
+    - mlflow=mlflow.cli:cli
 
 requirements:
   host:
@@ -80,7 +80,7 @@ requirements:
     - matplotlib-base <4
     - numpy <3
     - pandas <3
-    - pyarrow <18,>=4.0.0
+    - pyarrow <19,>=4.0.0
     - scikit-learn <2
     - scipy <2
     - sqlalchemy >=1.4.0,<3
@@ -88,10 +88,12 @@ requirements:
 {% endif %}
   run_constrained:
     - mlflow{{ mlflow_other }} <0a0
+    # extras
     - google-cloud-storage >=1.30.0
     - azureml-core >=1.2.0
-    - mlserver >=1.2.0, !=1.3.1, <1.4.0
-    - mlserver-mlflow >=1.2.0,!=1.3.1,<1.4.0
+    # mlserver
+    - mlserver >=1.2.0, !=1.3.1
+    - mlserver-mlflow >=1.2.0,!=1.3.1
     # mlflow-gateway, mlflow-skinny-gateway, genai
     - pydantic >=1.0,<3
     - fastapi <1
@@ -105,6 +107,8 @@ requirements:
     - azure-storage-file-datalake >12
     - google-cloud-storage >=1.30.0
     - boto3 >1
+    # langchain
+    - langchain >=0.1.0,<=0.3.7
 
 test:
   imports:
@@ -125,20 +129,28 @@ test:
 {% endif %}
   source_files:
     - tests/artifacts
+  requires:
+    - pip
+    - pytest
+    - pillow
+    - numpy
   commands:
     - mlflow --help
+    - mlflow --version
     - pip check
     # these tests come from the conda-forge recipe
 {% if mlflow_variant != "skinny" %}
     - mlflow recipes --help
     # This should not be packaged
-    - test ! -f $SP_DIR/pylint_plugins  # [unix]
+    - test ! -f $SP_DIR/pylint_plugins           # [unix]
+    - echo "Checking 'mlflow' exists..."         # [unix]
     - pip list | grep "mlflow \+${PKG_VERSION}"  # [unix]
     # smoke tests
     # skip test_log_artifact_windows_path_with_hostname (run only for win)
     # because needs a data file
     - pytest -vv tests/artifacts -k "not test_log_artifact_windows_path_with_hostname"
 {% else %}
+    - echo "Checking 'mlflow-skinny' exists..."         # [unix]
     - pip list | grep "mlflow-skinny \+${PKG_VERSION}"  # [unix]
     # smoke tests
     # skip test_load_image because numpy is not included in the skinny variant
@@ -148,11 +160,6 @@ test:
 {% endif %}
     # test from .github/workflows/test-package-build.yml#L97
     - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
-  requires:
-    - pip
-    - pytest
-    - pillow
-    - numpy
 
 about:
   home: https://mlflow.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "2.16.2" %}
+{% set version = "2.17.2" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -23,7 +23,7 @@ package:
 source:
   # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
-  sha256: d101bf639b7671408d67d357f4af207e8655a41d50ca3befa951026d49751e39
+  sha256: 84c6cad59877f1de177175ef619c0e0d6fe3e617b060cc75fbd2696b9e50e380
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,16 @@
 {% set name = "mlflow" %}
 {% set version = "2.18.0" %}
 
-# MLFlow offers two variants, a "normal" install and a "skinny" install with
-# a reduced installation and fewer dependencies. The skinny installation is obtained
-# by setting the environment variable MLFLOW_SKINNY at pip install time. For conda
-# we accomplish this with two conda packages, mflow and mlflow-skinny. Note that this
-# is not the same as matplotlib-base/matplotlib, where the only differences is the
-# dependency set; the installed code is different as well.
-
-{% if mlflow_variant == "skinny" %}
-{% set mlflow_suffix = "-skinny" %}
-{% set mlflow_other = "mlflow" %}
-{% else %}
-{% set mlflow_suffix = "" %}
-{% set mlflow_other = "mlflow-skinny" %}
-{% endif %}
-
 package:
-  name: mlflow{{ mlflow_suffix }}
+  name: mlflow-split
   version: {{ version }}
 
 source:
-  # Using github as source for mlflow-skinny which does not exist on PyPI
   url: https://github.com/mlflow/mlflow/archive/refs/tags/v{{ version }}.zip
   sha256: 910ad1e2fce93b412063637d465e9291c99678a3bbccbf2b4f7736887321f44b
 
 build:
   number: 0
-  skip: true  # [py<39 or s390x]
-  script: |
-{% if mlflow_variant == "skinny" %}
-    export MLFLOW_SKINNY=1  # [not win]
-    set MLFLOW_SKINNY=1  # [win]
-    cp {{ SRC_DIR }}/pyproject.toml orig_pyproject.toml  # [not win]
-    copy {{ SRC_DIR }}\pyproject.toml orig_pyproject.toml  # [win]
-    cp {{ SRC_DIR }}/pyproject.skinny.toml pyproject.toml  # [not win]
-    copy {{ SRC_DIR }}\pyproject.skinny.toml pyproject.toml  # [win]
-{% endif %}
-    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-{% if mlflow_variant == "skinny" %}
-    cp orig_pyproject.toml pyproject.toml  # [not win]
-    copy orig_pyproject.toml pyproject.toml  # [win]
-{% endif %}
-  entry_points:
-    - mlflow=mlflow.cli:cli
 
 requirements:
   host:
@@ -51,154 +18,177 @@ requirements:
     - python
     - setuptools
     - wheel
-  run:
-    - python
-    - cachetools >=5.0.0,<6
-    - click >=7.0,<9
-    - cloudpickle <4
-    - databricks-sdk >=0.20.0,<1
-    - gitpython >=3.1.9,<4
-    - importlib-metadata <9,>=3.7.0,!=4.7.0
-    - opentelemetry-api >=1.9.0,<3
-    - opentelemetry-sdk >=1.9.0,<3
-    - packaging <25
-    # required on imports for win
-    - pytz <2025  # [win]
-    - protobuf >=3.12.0,<6
-    - pyyaml >=5.1,<7
-    - requests >=2.17.3,<3
-    - sqlparse >=0.4.0,<1
-{% if mlflow_variant != "skinny" %}
-    - flask <4
-    - jinja2 <4,>=2.11  # [not win]
-    - jinja2 <4,>=3.0  # [win]
-    - alembic <2,!=1.10.0
-    - docker-py >=4.0.0,<8
-    - graphene <4
-    - gunicorn <24  # [not win]
-    - markdown >=3.3,<4
-    - matplotlib-base <4
-    - numpy <3
-    - pandas <3
-    - pyarrow <19,>=4.0.0
-    - scikit-learn <2
-    - scipy <2
-    - sqlalchemy >=1.4.0,<3
-    - waitress <4  # [win]
-{% endif %}
-  run_constrained:
-    - {{ mlflow_other }} <0a0
-    # extras
-    - google-cloud-storage >=1.30.0
-    - azureml-core >=1.2.0
-    # mlserver
-    - mlserver >=1.2.0, !=1.3.1
-    - mlserver-mlflow >=1.2.0,!=1.3.1
-    # mlflow-gateway, mlflow-skinny-gateway, genai
-    - pydantic >=1.0,<3
-    - fastapi <1
-    - uvicorn-standard <1
-    - watchfiles <1
-    - aiohttp <4
-    - boto3 >=1.28.56,<2
-    - tiktoken <1
-    - slowapi >=0.1.9,<1
-    # databricks
-    - azure-storage-file-datalake >12
-    - google-cloud-storage >=1.30.0
-    - boto3 >1
-    # langchain
-    - langchain >=0.1.0,<=0.3.7
 
-test:
-  imports:
-    - mlflow
-    - mlflow.entities
-    - mlflow.projects
-    - mlflow.protos
-    - mlflow.rfunc
-    - mlflow.store
-    - mlflow.tracking
-    - mlflow.utils
-{% if mlflow_variant != "skinny" %}
-    - mlflow.models
-    - mlflow.pyfunc
-    - mlflow.pytorch
-    - mlflow.sagemaker
-    - mlflow.server
-{% endif %}
-  source_files:
-    - tests/artifacts
-  requires:
-    - pip
-    - pytest
-    - pillow
-    - numpy
-  commands:
-    - mlflow --help
-    - mlflow --version
-    - pip check
-    # these tests come from the conda-forge recipe
-{% if mlflow_variant != "skinny" %}
-    - mlflow recipes --help
-    # This should not be packaged
-    - test ! -f $SP_DIR/pylint_plugins           # [unix]
-    - echo "Checking 'mlflow' exists..."         # [unix]
-    - pip list | grep "mlflow \+${PKG_VERSION}"  # [unix]
-    # smoke tests
-    # skip test_log_artifact_windows_path_with_hostname (run only for win)
-    # because needs a data file
-    - pytest -vv tests/artifacts -k "not test_log_artifact_windows_path_with_hostname"
-{% else %}
-    - echo "Checking 'mlflow-skinny' exists..."         # [unix]
-    - pip list | grep "mlflow-skinny \+${PKG_VERSION}"  # [unix]
-    # smoke tests
-    # skip test_load_image because numpy is not included in the skinny variant
-    # skip test_log_artifact_windows_path_with_hostname (run only for win)
-    # because needs a data file
-    - pytest -vv tests/artifacts -k "not (test_load_image or test_log_artifact_windows_path_with_hostname)"
-{% endif %}
-    # test from .github/workflows/test-package-build.yml#L97
-    - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
+outputs:
+  - name: mlflow-skinny
+    script: build-mlflow.sh   # [unix]
+    script: build-mlflow.bat  # [win]
+    version: {{ version }}
+    build:
+      entry_points:
+        - mlflow=mlflow.cli:cli
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+      run:
+        - python
+        - cachetools<6,>=5.0.0
+        - click >=7.0,<9
+        - cloudpickle <4
+        - databricks-sdk <1,>=0.20.0
+        - gitpython >=3.1.9,<4
+        - importlib-metadata <9,>=3.7.0,!=4.7.0
+        - opentelemetry-api<3,>=1.9.0
+        - opentelemetry-sdk<3,>=1.9.0
+        - packaging <25
+        - protobuf >=3.12.0,<6
+        # required on imports for win
+        - pytz <2025  # [win]
+        - pyyaml >=5.1,<7
+        - requests >=2.17.3,<3
+        - sqlparse >=0.4.0,<1
+      run_constrained:
+        - mlflow <0a0
+        # extras
+        - google-cloud-storage >=1.30.0
+        - azureml-core >=1.2.0
+        # mlserver
+        - mlserver >=1.2.0, !=1.3.1
+        - mlserver-mlflow >=1.2.0,!=1.3.1
+        # mlflow-gateway, mlflow-skinny-gateway, genai
+        - pydantic >=1.0,<3
+        - fastapi <1
+        - uvicorn-standard <1
+        - watchfiles <1
+        - aiohttp <4
+        - boto3 >=1.28.56,<2
+        - tiktoken <1
+        - slowapi >=0.1.9,<1
+        # databricks
+        - azure-storage-file-datalake >12
+        - google-cloud-storage >=1.30.0
+        - boto3 >1
+        # langchain
+        - langchain >=0.1.0,<=0.3.7
+    test:
+      imports:
+        - mlflow
+        - mlflow.entities
+        - mlflow.projects
+        - mlflow.protos
+        - mlflow.rfunc
+        - mlflow.store
+        - mlflow.tracking
+        - mlflow.utils
+      source_files:
+        - tests/artifacts
+      commands:
+        - mlflow --help
+        - mlflow --version
+        - pip list | grep "mlflow-skinny \+${PKG_VERSION}"  # [unix]
+        - pip check
+        - set  # [win]
+        # smoke tests
+        # skip test_load_image because numpy is not included in the skinny variant
+        # skip test_log_artifact_windows_path_with_hostname (run only for win)
+        # because needs a data file
+        - pytest -vv tests/artifacts -k "not (test_load_image or test_log_artifact_windows_path_with_hostname)"
+        # test from .github/workflows/test-package-build.yml#L97
+        - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
+      requires:
+        - pip
+        - pytest
+        - pillow
+        - numpy
+
+  - name: mlflow
+    script: build-mlflow.sh   # [unix]
+    script: build-mlflow.bat  # [win]
+    version: {{ version }}
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+      run:
+        - alembic <2,!=1.10
+        - docker-py >=4.0.0,<8
+        - flask <4
+        - graphene<4
+        - gunicorn <24  # [not win]
+        - jinja2 <4,>=2.11  # [not win]
+        - jinja2 <4,>=3.0  # [win]
+        - markdown <4,>=3.3
+        - matplotlib-base <4
+        - numpy <3
+        - pandas <3
+        - prometheus_flask_exporter <1
+        - pyarrow <19,>=4.0.0
+        - querystring_parser <2
+        - scikit-learn <2
+        - scipy <2
+        - sqlalchemy >=1.4.0,<3
+        - waitress <4  # [win]
+    test:
+      imports:
+        - mlflow
+        - mlflow.entities
+        - mlflow.models
+        - mlflow.projects
+        - mlflow.protos
+        - mlflow.pyfunc
+        - mlflow.pytorch
+        - mlflow.rfunc
+        - mlflow.sagemaker
+        - mlflow.server
+        - mlflow.server.prometheus_exporter
+        - mlflow.store
+        - mlflow.tracking
+        - mlflow.utils
+      source_files:
+        - tests/artifacts
+      commands:
+        - mlflow --help
+        - mlflow --version
+        - mlflow recipes --help
+        # This should not be packaged
+        - test ! -f $SP_DIR/pylint_plugins  # [unix]
+        - pip check
+        - pip list | grep "mlflow \+${PKG_VERSION}"  # [unix]
+        - set  # [win]
+        # smoke tests
+        # skip test_log_artifact_windows_path_with_hostname (run only for win)
+        # because needs a data file
+        - pytest -vv tests/artifacts -k "not test_log_artifact_windows_path_with_hostname"
+        # test from .github/workflows/test-package-build.yml#L97
+        - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
+      requires:
+        - pip
+        - pytest
+        - pillow
+        - numpy
 
 about:
-  home: https://mlflow.org
-{% if mlflow_variant == "skinny" %}
-  summary: "MLflow Skinny: A Lightweight Machine Learning Lifecycle Platform Client"
-  description: |
-    MLflow Skinny is a lightweight MLflow package without SQL storage, server,
-    UI, or data science dependencies.
-{% else %}
-  summary: "MLflow: A Machine Learning Lifecycle Platform"
-  description: |
-    MLflow is a platform to streamline machine learning development, including tracking
-    experiments, packaging code into reproducible runs, and sharing and deploying models.
-    MLflow offers a set of lightweight APIs that can be used with any existing machine
-    learning application or library (TensorFlow, PyTorch, XGBoost, etc), wherever you
-    currently run ML code (e.g. in notebooks, standalone applications or the cloud).
-{% endif %}
+  home: https://mlflow.org/
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.txt
+  summary: MLflow is an open source platform for the machine learning lifecycle.
   doc_url: https://mlflow.org
   dev_url: https://github.com/mlflow/mlflow
 
 extra:
   feedstock-name: mlflow
   recipe-maintainers:
+    - daniellok-db
+    - B-Step62
+    - serena-ruan
+    - BenWilson2
+    - WeichenXu123
     - harupy
-    - aarondav
-    - ahirreddy
-    - andrewmchen
-    - aveshcsingh
     - dbczumar
     - jaroslawk
-    - mateiz
-    - mparkhe
-    - pogil
-    - smurching
-    - sueann
-    - tomasatdatabricks
     - xhochy
-    - zangr
     - janjagusch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@
 
 {% if mlflow_variant == "skinny" %}
 {% set mlflow_suffix = "-skinny" %}
-{% set mlflow_other = "" %}
+{% set mlflow_other = "mlflow" %}
 {% else %}
 {% set mlflow_suffix = "" %}
-{% set mlflow_other = "-skinny" %}
+{% set mlflow_other = "mlflow-skinny" %}
 {% endif %}
 
 package:
@@ -37,7 +37,7 @@ build:
     cp {{ SRC_DIR }}/pyproject.skinny.toml pyproject.toml  # [not win]
     copy {{ SRC_DIR }}\pyproject.skinny.toml pyproject.toml  # [win]
 {% endif %}
-    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+    {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 {% if mlflow_variant == "skinny" %}
     cp orig_pyproject.toml pyproject.toml  # [not win]
     copy orig_pyproject.toml pyproject.toml  # [win]
@@ -87,7 +87,7 @@ requirements:
     - waitress <4  # [win]
 {% endif %}
   run_constrained:
-    - mlflow{{ mlflow_other }} <0a0
+    - {{ mlflow_other }} <0a0
     # extras
     - google-cloud-storage >=1.30.0
     - azureml-core >=1.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,14 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<39 or s390x]
 
 requirements:
   host:
-    - pip
     - python
-    - setuptools
-    - wheel
+    - pip
+  run:
+    - python
 
 outputs:
   - name: mlflow-skinny
@@ -25,6 +26,7 @@ outputs:
     script: build-mlflow.bat  # [win]
     version: {{ version }}
     build:
+      skip: true  # [py<39 or s390x]
       entry_points:
         - mlflow=mlflow.cli:cli
     requirements:
@@ -32,6 +34,7 @@ outputs:
         - pip
         - python
         - setuptools
+        - wheel
       run:
         - python
         - cachetools<6,>=5.0.0
@@ -84,9 +87,15 @@ outputs:
         - mlflow.utils
       source_files:
         - tests/artifacts
+      requires:
+        - pip
+        - pytest
+        - pillow
+        - numpy
       commands:
         - mlflow --help
         - mlflow --version
+        - echo "Checking 'mlflow-skinny' exists..."         # [unix]
         - pip list | grep "mlflow-skinny \+${PKG_VERSION}"  # [unix]
         - pip check
         - set  # [win]
@@ -97,40 +106,89 @@ outputs:
         - pytest -vv tests/artifacts -k "not (test_load_image or test_log_artifact_windows_path_with_hostname)"
         # test from .github/workflows/test-package-build.yml#L97
         - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
-      requires:
-        - pip
-        - pytest
-        - pillow
-        - numpy
+
+    about:
+      home: https://mlflow.org
+      summary: "MLflow Skinny: A Lightweight Machine Learning Lifecycle Platform Client"
+      description: |
+        MLflow Skinny is a lightweight MLflow package without SQL storage, server,
+        UI, or data science dependencies.
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: LICENSE.txt
+      doc_url: https://mlflow.org
+      dev_url: https://github.com/mlflow/mlflow
 
   - name: mlflow
     script: build-mlflow.sh   # [unix]
     script: build-mlflow.bat  # [win]
     version: {{ version }}
+    build:
+      skip: true  # [py<39 or s390x]
+      entry_points:
+        - mlflow=mlflow.cli:cli
     requirements:
       host:
         - pip
         - python
         - setuptools
+        - wheel
       run:
-        - alembic <2,!=1.10
-        - docker-py >=4.0.0,<8
+        - python
+        - cachetools >=5.0.0,<6
+        - click >=7.0,<9
+        - cloudpickle <4
+        - databricks-sdk >=0.20.0,<1
+        - gitpython >=3.1.9,<4
+        - importlib-metadata <9,>=3.7.0,!=4.7.0
+        - opentelemetry-api >=1.9.0,<3
+        - opentelemetry-sdk >=1.9.0,<3
+        - packaging <25
+        # required on imports for win
+        - pytz <2025  # [win]
+        - protobuf >=3.12.0,<6
+        - pyyaml >=5.1,<7
+        - requests >=2.17.3,<3
+        - sqlparse >=0.4.0,<1
         - flask <4
-        - graphene<4
-        - gunicorn <24  # [not win]
         - jinja2 <4,>=2.11  # [not win]
         - jinja2 <4,>=3.0  # [win]
-        - markdown <4,>=3.3
+        - alembic <2,!=1.10.0
+        - docker-py >=4.0.0,<8
+        - graphene <4
+        - gunicorn <24  # [not win]
+        - markdown >=3.3,<4
         - matplotlib-base <4
         - numpy <3
         - pandas <3
-        - prometheus_flask_exporter <1
         - pyarrow <19,>=4.0.0
-        - querystring_parser <2
         - scikit-learn <2
         - scipy <2
         - sqlalchemy >=1.4.0,<3
         - waitress <4  # [win]
+      run_constrained:
+        - mlflow-skinny <0a0
+        # extras
+        - google-cloud-storage >=1.30.0
+        - azureml-core >=1.2.0
+        # mlserver
+        - mlserver >=1.2.0, !=1.3.1
+        - mlserver-mlflow >=1.2.0,!=1.3.1
+        # mlflow-gateway, mlflow-skinny-gateway, genai
+        - pydantic >=1.0,<3
+        - fastapi <1
+        - uvicorn-standard <1
+        - watchfiles <1
+        - aiohttp <4
+        - boto3 >=1.28.56,<2
+        - tiktoken <1
+        - slowapi >=0.1.9,<1
+        # databricks
+        - azure-storage-file-datalake >12
+        - google-cloud-storage >=1.30.0
+        - boto3 >1
+        # langchain
+        - langchain >=0.1.0,<=0.3.7
     test:
       imports:
         - mlflow
@@ -143,12 +201,16 @@ outputs:
         - mlflow.rfunc
         - mlflow.sagemaker
         - mlflow.server
-        - mlflow.server.prometheus_exporter
         - mlflow.store
         - mlflow.tracking
         - mlflow.utils
       source_files:
         - tests/artifacts
+      requires:
+        - pip
+        - pytest
+        - pillow
+        - numpy
       commands:
         - mlflow --help
         - mlflow --version
@@ -156,6 +218,7 @@ outputs:
         # This should not be packaged
         - test ! -f $SP_DIR/pylint_plugins  # [unix]
         - pip check
+        - echo "Checking 'mlflow' exists..."         # [unix]
         - pip list | grep "mlflow \+${PKG_VERSION}"  # [unix]
         - set  # [win]
         # smoke tests
@@ -164,11 +227,21 @@ outputs:
         - pytest -vv tests/artifacts -k "not test_log_artifact_windows_path_with_hostname"
         # test from .github/workflows/test-package-build.yml#L97
         - python -c "import mlflow; print(mlflow.__version__); assert(mlflow.__version__ == '{{ version }}');"
-      requires:
-        - pip
-        - pytest
-        - pillow
-        - numpy
+    
+    about:
+      home: https://mlflow.org
+      summary: "MLflow: A Machine Learning Lifecycle Platform"
+      description: |
+        MLflow is a platform to streamline machine learning development, including tracking
+        experiments, packaging code into reproducible runs, and sharing and deploying models.
+        MLflow offers a set of lightweight APIs that can be used with any existing machine
+        learning application or library (TensorFlow, PyTorch, XGBoost, etc), wherever you
+        currently run ML code (e.g. in notebooks, standalone applications or the cloud).
+      license: Apache-2.0
+      license_family: APACHE
+      license_file: LICENSE.txt
+      doc_url: https://mlflow.org
+      dev_url: https://github.com/mlflow/mlflow
 
 about:
   home: https://mlflow.org/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6051](https://anaconda.atlassian.net/browse/PKG-6051) 
- [Upstream repository](https://github.com/mlflow/mlflow/tree/v2.18.0)
- Requirements:
  - https://github.com/mlflow/mlflow/blob/v2.18.0/pyproject.skinny.toml
  - https://github.com/mlflow/mlflow/blob/v2.18.0/requirements/skinny-requirements.txt
  - https://github.com/mlflow/mlflow/blob/v2.18.0/pyproject.toml 
  - https://github.com/mlflow/mlflow/blob/v2.18.0/requirements/core-requirements.txt

### Explanation of changes:

- Rewriting as a multi-output recipe because of catching a [conda-build bug](https://github.com/conda/conda-build/issues/5416) on **win-64** (see the previous draft PR https://github.com/AnacondaRecipes/mlflow-feedstock/pull/8), the fix won't be available until the next release of conda-build in January 2025 (???), see https://github.com/conda/conda-build/pull/5417
  - conda-build 24.11.2 is expected to fix the issue https://github.com/conda/conda-build/issues/5524 
- Make changes based on the conda-forge recipe:
  - Add README_SKINNY.rst 
  - Add build-mlflow.bat and build-mlflow.sh
  - Remove conda_build_config.yaml as we do not rely on jinja2 variants and selectors.
- Skip py<39
- Add to `run_constrained`:
  -  `mlflow <0a0` for the `mlflow-skinny` subpackage to prevent installing `mlflow` to the same environment
  -  `mlflow-skinny <0a0` for the `mlflow` subpackage to prevent installing `mlflow-skinny` to the same environment
- Add separate `about` sections to every output. They have different summaries and descriptions

### Notes:

-

[PKG-6051]: https://anaconda.atlassian.net/browse/PKG-6051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ