### PR TITLE
Add anaconda.yaml for mlflow/mlflow-skinny upstream tracking

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,10 @@
+anaconda_config_version: 1
+upstream_sources:
+  - github:
+      identifier: mlflow/mlflow
+      use_max_tag: true
+      include_regex: ^v\d+\.\d+\.\d+$
+      prefix: v
+    packages:
+      - mlflow
+      - mlflow-skinny


### PR DESCRIPTION
## Summary
- add missing anaconda.yaml for mlflow-feedstock
- track upstream from mlflow/mlflow release tags using prefix: v
- include both package lines (mlflow, mlflow-skinny) for distro-db / generator parity

## Context
PDA-1770 gap: feedstock lacked anaconda.yaml, so upstream version tracking was not configured.

## Validation
- inspected recipe variants in recipe/meta.yaml
- verified upstream tag family and mlflow-skinny release history references