### PR TITLE
mlflow 3.12.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlflow" %}
-{% set version = "3.10.1" %}
+{% set version = "3.12.0" %}
 
 # MLFlow offers two variants, a "normal" install and a "skinny" install with
 # a reduced installation and fewer dependencies. The skinny installation is obtained
@@ -32,7 +32,7 @@ source:
   # those packages aren't installed in our build. Converting to a multi-output
   # recipe would be needed to use pyproject.release.toml correctly.
   url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1efe3674245a6058347d20f95f74506bbb7c65f6831f4c9eebffdf4b60420b24
+  sha256: d13c303b0bfdf1ca238717e69d1ac8005ae2226e236e245669706cd5eaab1d78
 
 build:
   number: 0
@@ -52,22 +52,24 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
+    - setuptools <=82.0.1
     - wheel
   run:
     - python
+    - aiohttp <4
+    - starlette <1
     - cachetools >=5.0.0,<8
     - click >=7.0,<9
     - cloudpickle <4
     - databricks-sdk >=0.20.0,<1
     - fastapi <1
     - gitpython >=3.1.9,<4
-    - importlib-metadata >=3.7.0,<9,!=4.7.0
+    - importlib-metadata >=3.7.0,<10,!=4.7.0
     - opentelemetry-api >=1.9.0,<3
     - opentelemetry-proto >=1.9.0,<3
     - opentelemetry-sdk >=1.9.0,<3
     - packaging <27
-    - protobuf >=3.12.0,<7
+    - protobuf >=3.12.0,<8
     - pydantic >=2,<3
     - python-dotenv >=0.19.0,<2
     - pyyaml >=5.1,<7
@@ -86,7 +88,6 @@ requirements:
     - graphene <4
     - huey >=2.5.4,<3
     - gunicorn <26  # [not win]
-    - markdown >=3.3,<4
     - matplotlib-base <4
     - numpy <3
     - pandas <3
@@ -105,10 +106,7 @@ requirements:
     # mlserver
     - mlserver >=1.2.0,!=1.3.1,<2.0.0
     - mlserver-mlflow >=1.2.0,!=1.3.1,<2.0.0
-    # genai
-    - aiohttp <4
     #- boto3 <2,>=1.28.56
-    - fastapi <1
     - slowapi <1,>=0.1.9
     - tiktoken <1
     - uvicorn-standard <1
@@ -173,11 +171,11 @@ test:
 
 about:
   home: https://mlflow.org
-  summary: "{{ summary_text }}"
-  description: "{{ description_text }}"
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE.txt
+  summary: "{{ summary_text }}"
+  description: "{{ description_text }}"
   doc_url: https://mlflow.org
   dev_url: https://github.com/mlflow/mlflow
 


### PR DESCRIPTION
mlflow 3.12.0

**Destination channel:** Defaults

### Links

- [PKG-14490]
- dev_url:        https://github.com/mlflow/mlflow/tree/v3.12.0
- conda_forge:    https://github.com/conda-forge/mlflow-feedstock
- pypi:           https://pypi.org/project/mlflow/3.12.0
- pypi inspector: https://inspector.pypi.io/project/mlflow/3.12.0

### Explanation of changes:

- new version number


[PKG-14490]: https://anaconda.atlassian.net/browse/PKG-14490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ